### PR TITLE
Fix in-domain training settings

### DIFF
--- a/configs/mrt_in_domain.yaml
+++ b/configs/mrt_in_domain.yaml
@@ -33,7 +33,7 @@ training:
     learning_rate_min: 0.00000005
     weight_decay: 0.0
     label_smoothing: 0.1
-    batch_size: 64
+    batch_size: 32
     eval_batch_size: 128
     batch_multiplier: 4
     batch_type: "token"
@@ -76,22 +76,22 @@ model:
         num_layers: 6
         num_heads: 4
         embeddings:
-            embedding_dim: 128
+            embedding_dim: 256
             scale: True
             dropout: 0.
         # typically ff_size = 4 x hidden_size
-        hidden_size: 128
-        ff_size: 512
+        hidden_size: 256
+        ff_size: 1024
         dropout: 0.3
     decoder:
         type: "transformer"
         num_layers: 6
         num_heads: 4
         embeddings:
-            embedding_dim: 128
+            embedding_dim: 256
             scale: True
             dropout: 0.
         # typically ff_size = 4 x hidden_size
-        hidden_size: 128
-        ff_size: 512
+        hidden_size: 256
+        ff_size: 1024
         dropout: 0.3

--- a/configs/pg_in_domain.yaml
+++ b/configs/pg_in_domain.yaml
@@ -33,7 +33,7 @@ training:
   learning_rate_min: 0.00000005
   weight_decay: 0.0
   label_smoothing: 0.1
-  batch_size: 256
+  batch_size: 128
   batch_type: "token"
   early_stopping_metric: "eval_metric"
   epochs: 10
@@ -74,22 +74,22 @@ model:
     num_layers: 6
     num_heads: 4
     embeddings:
-      embedding_dim: 128
+      embedding_dim: 256
       scale: True
       dropout: 0.
         # typically ff_size = 4 x hidden_size
-    hidden_size: 128
-    ff_size: 512
+    hidden_size: 256
+    ff_size: 1024
     dropout: 0.3
   decoder:
     type: "transformer"
     num_layers: 6
     num_heads: 4
     embeddings:
-      embedding_dim: 128
+      embedding_dim: 256
       scale: True
       dropout: 0.
         # typically ff_size = 4 x hidden_size
-    hidden_size: 128
-    ff_size: 512
+    hidden_size: 256
+    ff_size: 1024
     dropout: 0.3


### PR DESCRIPTION
I think some values in `pg_in_domain` and `mrt_in_domain` configs are different from the appendix in the paper.
I'd appreciate it if you could merge.