### PR TITLE
Use torchtext legacy APIs

### DIFF
--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -9,9 +9,8 @@ import os.path
 from typing import Optional
 import logging
 
-from torchtext.datasets import TranslationDataset
-from torchtext import data
-from torchtext.data import Dataset, Iterator, Field
+from torchtext.legacy.datasets import TranslationDataset
+from torchtext.legacy.data import Dataset, Iterator, Field, BucketIterator
 
 from joeynmt.constants import UNK_TOKEN, EOS_TOKEN, BOS_TOKEN, PAD_TOKEN
 from joeynmt.vocabulary import build_vocab, Vocabulary
@@ -62,13 +61,13 @@ def load_data(data_cfg: dict, datasets: list = None)\
 
     tok_fun = lambda s: list(s) if level == "char" else s.split()
 
-    src_field = data.Field(init_token=None, eos_token=EOS_TOKEN,
+    src_field = Field(init_token=None, eos_token=EOS_TOKEN,
                            pad_token=PAD_TOKEN, tokenize=tok_fun,
                            batch_first=True, lower=lowercase,
                            unk_token=UNK_TOKEN,
                            include_lengths=True)
 
-    trg_field = data.Field(init_token=BOS_TOKEN, eos_token=EOS_TOKEN,
+    trg_field = Field(init_token=BOS_TOKEN, eos_token=EOS_TOKEN,
                            pad_token=PAD_TOKEN, tokenize=tok_fun,
                            unk_token=UNK_TOKEN,
                            batch_first=True, lower=lowercase,
@@ -182,14 +181,14 @@ def make_data_iter(dataset: Dataset,
 
     if train:
         # optionally shuffle and sort during training
-        data_iter = data.BucketIterator(
+        data_iter = BucketIterator(
             repeat=False, sort=False, dataset=dataset,
             batch_size=batch_size, batch_size_fn=batch_size_fn,
             train=True, sort_within_batch=True,
             sort_key=lambda x: len(x.src), shuffle=shuffle)
     else:
         # don't sort/shuffle for validation/inference
-        data_iter = data.BucketIterator(
+        data_iter = BucketIterator(
             repeat=False, dataset=dataset,
             batch_size=batch_size, batch_size_fn=batch_size_fn,
             train=False, sort=False)

--- a/joeynmt/helpers.py
+++ b/joeynmt/helpers.py
@@ -19,7 +19,7 @@ import torch
 from torch import nn, Tensor
 from torch.utils.tensorboard import SummaryWriter
 
-from torchtext.data import Dataset
+from torchtext.legacy.data import Dataset
 import yaml
 from joeynmt.vocabulary import Vocabulary
 from joeynmt.plotting import plot_heatmap

--- a/joeynmt/prediction.py
+++ b/joeynmt/prediction.py
@@ -9,7 +9,7 @@ import logging
 import numpy as np
 
 import torch
-from torchtext.data import Dataset, Field
+from torchtext.legacy.data import Dataset, Field
 
 from joeynmt.helpers import bpe_postprocess, load_config, make_logger,\
     get_latest_checkpoint, load_checkpoint, store_attention_plots

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -21,7 +21,7 @@ import torch
 from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
-from torchtext.data import Dataset
+from torchtext.legacy.data import Dataset
 from joeynmt.model import build_model
 from joeynmt.batch import Batch
 from joeynmt.helpers import log_data_info, load_config, log_cfg, \

--- a/joeynmt/vocabulary.py
+++ b/joeynmt/vocabulary.py
@@ -7,7 +7,7 @@ from collections import defaultdict, Counter
 from typing import List
 import numpy as np
 
-from torchtext.data import Dataset
+from torchtext.legacy.data import Dataset
 
 from joeynmt.constants import UNK_TOKEN, DEFAULT_UNK_ID, \
     EOS_TOKEN, BOS_TOKEN, PAD_TOKEN


### PR DESCRIPTION
Currently, the version of torchtext specified in [requirements.txt](https://github.com/samuki/reinforce-joey/blob/55046e04baf2b74fbcc9714a2e4fc0ddbb2f6401/requirements.txt#L7) is 0.9.0, but the code in the joeynmt package does not support [the backwards incompatible changes](https://github.com/pytorch/text/releases/tag/v0.9.0-rc5) made in this version.

I have fixed it by using legacy package according to [the migration guide](https://github.com/pytorch/text/blob/master/examples/legacy_tutorial/migration_tutorial.ipynb).
If you do not plan to use the new torchtext APIs, could you please merge this?
I have confirmed that the both training and test scripts work fine.